### PR TITLE
Add Slack slash command planner integration

### DIFF
--- a/chat/slack_agent.py
+++ b/chat/slack_agent.py
@@ -1,0 +1,49 @@
+"""Slack bot that plans actions based on user goals."""
+from __future__ import annotations
+
+from typing import Dict
+
+from slack_bolt import App
+
+from planner.planner import plan
+
+# In-memory store mapping user IDs to their latest goal
+USER_GOALS: Dict[str, str] = {}
+
+
+def create_app(token: str, signing_secret: str) -> App:
+    """Create a Slack Bolt app that handles the /goblin slash command.
+
+    Parameters
+    ----------
+    token: str
+        Slack bot token.
+    signing_secret: str
+        Slack signing secret.
+
+    Returns
+    -------
+    App
+        Configured Slack Bolt application.
+    """
+    app = App(token=token, signing_secret=signing_secret)
+
+    @app.command("/goblin")
+    def handle_goblin(ack, respond, command):
+        """Handle the /goblin slash command.
+
+        The command text is stored as the user's goal and sent to the LLM
+        planner. A summary of the plan is then posted back to Slack.
+        """
+        ack()
+        user_id = command.get("user_id")
+        text = command.get("text", "").strip()
+        if user_id:
+            USER_GOALS[user_id] = text
+        try:
+            plan_summary = plan(text)
+        except Exception as exc:  # pragma: no cover - network errors
+            plan_summary = f"Planning failed: {exc}"
+        respond(plan_summary)
+
+    return app

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@
 import os
 from dotenv import load_dotenv
 
-from chat.slack_bot import create_app
+from chat.slack_agent import create_app
 from planner.planner import plan
 from wallet.solana_wallet import get_balance
 from tools.defi_agent import fetch_opportunities


### PR DESCRIPTION
## Summary
- add Slack agent handling `/goblin` slash command
- store user goals and route to LLM planner
- wire main application to new Slack agent

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc1811dbd883229b1632a675c45998